### PR TITLE
Switch to uwsgi instead of gunicorn

### DIFF
--- a/python/cherrypy/config.yaml
+++ b/python/cherrypy/config.yaml
@@ -3,9 +3,8 @@ framework:
   version: 18.3
 
 command: >
-  gunicorn  \
-    --log-level warning  \
-    --bind 0.0.0.0:3000  \
-    --reuse-port  \
-    --workers $(nproc)  \
-      server:app
+  uwsgi \
+    --socket 0.0.0.0:3000 \
+    --protocol=http \
+    --wsgi-file server.py \
+    --callable app

--- a/python/cherrypy/config.yaml
+++ b/python/cherrypy/config.yaml
@@ -5,6 +5,7 @@ framework:
 command: >
   uwsgi \
     --socket 0.0.0.0:3000 \
+    --async 10 \
     --protocol=http \
     --wsgi-file server.py \
     --callable app

--- a/python/cherrypy/requirements.txt
+++ b/python/cherrypy/requirements.txt
@@ -1,2 +1,2 @@
 cherrypy>=18.3.0,<19.4.0
-gunicorn
+uwsgi


### PR DESCRIPTION
Hi @murilobr,

This `PR` switch from `gunicorn` to `uwsgi`

The performance are slightly the same, but `uwsgi` is referenced in `cherrypy` doc :stuck_out_tongue: 

@webknjaz Do you approve this change ?

Regards,

PS : Do not merge until approval